### PR TITLE
Fix(rust): update the autorand crate version

### DIFF
--- a/templates/rs/static/Cargo.toml
+++ b/templates/rs/static/Cargo.toml
@@ -10,6 +10,6 @@ serde = { version = "1.0",  features = ["derive"] }
 serde_json = "1.0"
 
 [dev-dependencies]
-autorand = { version = "0.2", features = ["json", "json-value-always-null"] }
+autorand = { version = "0.2.1", features = ["json", "json-value-always-null"] }
 futures = "0.1.25"
 failure = "0.1.5"


### PR DESCRIPTION
Updating the version of the autorand crate will fix the bug with floating point arithmetic errors breaking the tests sometimes

Not the f32/f64 random values are fixed at 3 decimal places.