### PR TITLE
fix: pass correct arguments to rpc client

### DIFF
--- a/templates/js/templated/exported-class.template.ts
+++ b/templates/js/templated/exported-class.template.ts
@@ -70,7 +70,7 @@ export default class <%= className %> {
     if (methodObject.paramStructure && methodObject.paramStructure === "by-name") {
       rpcParams = _.zipObject(params, _.map(methodObject.params, "name"));
     } else {
-      rpcParams = Array.from(arguments);
+      rpcParams = params;
     }
     const result: any = this.rpc.request(methodName, rpcParams);
     return result.then((r: any) => r.result);


### PR DESCRIPTION
This fixes an issue that I encountered testing live. Essentially the rpc request was pulling in the method name into parameters, because arguments is contextual based off of the scope of the existing function. The fix was to just pass parameters directly in the case of non named parameters. 
