### PR TITLE
Fix/rust generator integer to float overflow error

### DIFF
--- a/templates/rust/static/Cargo.toml
+++ b/templates/rust/static/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "template-client"
 version = "1.0.0"
-authors = ["Zachary Belford <belfordz66@gmail.com>"]
+authors = ["Zachary Belford <belfordz66@gmail.com>", "Mike Lubinets <public@mersinvald.me>"]
 edition = "2018"
 
 [dependencies]
@@ -10,6 +10,6 @@ serde = { version = "1.0",  features = ["derive"] }
 serde_json = "1.0"
 
 [dev-dependencies]
-autorand = { version = "0.2.1", features = ["json", "json-value-always-null"] }
+autorand = { version = "0.2.2", features = ["json", "json-value-always-null", "limited-integers"] }
 futures = "0.1.25"
 failure = "0.1.5"


### PR DESCRIPTION
This PR should fix an issue with untagged enums where integers end up being treated as floating-point numbers, causing an overflow bug and a test failure.

